### PR TITLE
Added 60dB integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 voices.json
+voices_60db.json
 output.wav
 chats/

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Cortana is an AI-powered python library for achieving several tasks:
 
 - chatting with GPT via command line
 - doing speech to text with openai-whisper
-- doing text to speech with elevenlabs
-- creating a personal assistant with whisper, GPT, and elevenlabs
-- speaking with a different voice using whisper and elevenlabs
+- doing text to speech with elevenlabs or 60db (pick your provider)
+- creating a personal assistant with whisper, GPT, and your chosen TTS provider
+- speaking with a different voice using whisper and your chosen TTS provider
 
 Example dialogue (user speaks into microphone, assistant speaks responses back):
 
@@ -24,7 +24,7 @@ Assistant: An oat cream IPA, huh? Sounds smooth and intriguing, just like you! A
 
 ## How it works
 
-Cortana uses whisper to do speech to text, and then uses GPT to generate a response. It then uses elevenlabs to do text to speech, and plays the audio.
+Cortana uses whisper to do speech to text, and then uses GPT to generate a response. It then uses a text-to-speech provider (elevenlabs or 60db, configurable via `TTS_PROVIDER`) to do text to speech, and plays the audio.
 
 The assistant mode has a hotword detection system, so that you can say your desired to activate the assistant. It then listens for a command, and then responds. It'll ignore any commands that don't include the hotword.
 
@@ -42,6 +42,24 @@ cp example.env .env
 ```
 
 Enter your API keys in the .env file, and change the name + voice. The voice should be one of the voices available in the [elevenlabs API](https://elevenlabs.io/) - either default voices or one that you've cloned. It'll pick the first voice that matches (case-insensitive.)
+
+### Choosing a TTS provider
+
+Cortana can synthesise speech with either [ElevenLabs](https://elevenlabs.io/) or [60db](https://docs.60db.ai). Set the default in `.env`:
+
+```bash
+TTS_PROVIDER=elevenlabs   # or 60db
+```
+
+and override it for a single run with `--provider`:
+
+```bash
+python cli.py full --provider 60db
+python cli.py tts --provider elevenlabs
+python cli.py clone --provider 60db
+```
+
+Each provider has its own keys, voice name, and voice settings in `.env` (`ELEVENLABS_*` use 0–1 stability/similarity, `SIXTYDB_*` use 0–100). For 60db the configured voice is matched (case-insensitive) against your own voices from `/myvoices`. Both providers play back identically — buffered mp3 — so switching is seamless. 60db voices are cached to `voices_60db.json` (delete to refresh, same as `voices.json`).
 
 For audio setup, I use a virtual audio mixer. If you don't have a mixer, go and look in your audio devices to see what the device names are, and set them in the .env file.
 
@@ -62,15 +80,15 @@ python cli.py full
 
 By default it will use gpt-4. If you do not have API access to GPT-4, change the model to gpt-3.5-turbo in the .env file.
 
-Also assumes you have an API key for elevenlabs. If you don't, you can get one for free with some trial characters at [elevenlabs](https://elevenlabs.io/).
+Also assumes you have an API key for your chosen TTS provider. For elevenlabs you can get one for free with some trial characters at [elevenlabs](https://elevenlabs.io/); for 60db see [docs.60db.ai](https://docs.60db.ai). You only need a key for the provider you actually use.
 
 If you find that the whisper tiny model is not accurate enough, bump the model size to small or medium. Has a trade-off of speed, but the accuracy is much better. I find the 'small' model works pretty well without any fine-tuning.
 
-Voices are cached to voices.json to save on API calls. If you want to refresh the voices, delete the file.
+Voices are cached to save on API calls (`voices.json` for elevenlabs, `voices_60db.json` for 60db). If you want to refresh the voices, delete the file.
 
 ## Limitations
 
-Currently does not do streaming from elevenlabs - haven't yet figured out how to make the playback experience not awful. If you have any ideas, please let me know!
+Currently does not do streaming - playback is buffered for both providers (the whole clip is generated, then played). 60db does offer NDJSON and WebSocket streaming, so progressive playback is a possible future improvement. If you have any ideas, please let me know!
 
 ## Future goals / todos
 

--- a/cli.py
+++ b/cli.py
@@ -15,9 +15,10 @@ def cli():
     pass
 
 @cli.command()
-def tts() -> None:
+@click.option('--provider', default=None, help='TTS provider: elevenlabs or 60db (overrides TTS_PROVIDER)')
+def tts(provider: str | None) -> None:
     click.echo('Text to speech')
-    tts_loop()
+    tts_loop(provider=provider)
 
 @cli.command()
 def stt() -> None:
@@ -32,14 +33,16 @@ def chat_gpt() -> None:
 
 @cli.command()
 @click.option('--with-tts/--no-tts', default=True, help='Include text-to-speech (TTS) in full mode')
-def full(with_tts: bool) -> None:
+@click.option('--provider', default=None, help='TTS provider: elevenlabs or 60db (overrides TTS_PROVIDER)')
+def full(with_tts: bool, provider: str | None) -> None:
     click.echo('Full mode')
-    full_pipeline(with_tts=with_tts)
+    full_pipeline(with_tts=with_tts, provider=provider)
 
 @cli.command()
-def clone() -> None:
+@click.option('--provider', default=None, help='TTS provider: elevenlabs or 60db (overrides TTS_PROVIDER)')
+def clone(provider: str | None) -> None:
     click.echo('Clone mode')
-    clone_pipeline()
+    clone_pipeline(provider=provider)
 
 if __name__ == '__main__':
     cli()

--- a/cortana/api.py
+++ b/cortana/api.py
@@ -7,6 +7,7 @@ load_dotenv(override=True)
 class ApiType(enum.Enum):
     ELEVENLABS = os.environ.get('ELEVENLABS_API_URL')
     OPENAI = os.environ.get('OPENAI_API_URL')
+    SIXTYDB = os.environ.get('SIXTYDB_API_URL')
 
 
 Method = Literal['GET', 'POST', 'PUT', 'DELETE']
@@ -27,7 +28,11 @@ def build_auth_header(api_type: ApiType) -> dict[Any, Any]:
         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
         "OpenAI-Organization": os.environ.get('OPENAI_ORG_ID'),
     }}
-    
+    if api_type == ApiType.SIXTYDB:
+        header = {**header, **{
+        "Authorization": f"Bearer {os.environ.get('SIXTYDB_API_KEY')}",
+    }}
+
     return header
 
 
@@ -35,9 +40,8 @@ def make_api_request(method: Method, api_type: ApiType, url: str, data: dict[Any
     headers = build_auth_header(api_type)
     url = f"https://{api_type.value}{url}"
     response = requests.request(method, url, headers=headers, json=data, stream=stream)
-    if not stream and response.headers['Content-Type'] != 'application/json':
-        return response
-    if not stream and response.headers['Content-Type'] == 'application/json':
-        return response.json()
     if stream:
         return response
+    if 'application/json' in response.headers.get('Content-Type', ''):
+        return response.json()
+    return response

--- a/cortana/app.py
+++ b/cortana/app.py
@@ -39,7 +39,7 @@ def check_for_hotword_or_hotword_corrections(text: str) -> str:
     raise ValueError('Hotword not found')
 
 
-def full_pipeline(with_tts: bool = True):
+def full_pipeline(with_tts: bool = True, provider: str | None = None):
     message_list = create_message_list_with_prompt()
     if not (chat_folder:=Path('chats')).exists():
         chat_folder.mkdir()
@@ -55,7 +55,7 @@ def full_pipeline(with_tts: bool = True):
             text = check_for_hotword_or_hotword_corrections(text)
             response = pluggable_chat_loop(message_list, text)
             if with_tts:
-                tts_loop(response[-1]['content'])
+                tts_loop(response[-1]['content'], provider=provider)
             else:
                 print(response[-1]['content'])
 
@@ -65,7 +65,7 @@ def full_pipeline(with_tts: bool = True):
             pass
 
 
-def clone_pipeline():
+def clone_pipeline(provider: str | None = None):
     while True:
         text = stt_loop()
-        tts_loop(text)
+        tts_loop(text, provider=provider)

--- a/cortana/tts.py
+++ b/cortana/tts.py
@@ -1,70 +1,23 @@
 """
-Text to speech module that plugs into ElevenLabs.io
+Text to speech module.
+
+Synthesis is delegated to a pluggable provider (ElevenLabs or 60db) defined in
+cortana/tts_providers.py; this module only handles device selection and playback,
+so the behaviour is identical regardless of which provider is active.
 """
 from dotenv import load_dotenv
 load_dotenv(override=True)
 import os
-from typing import Any, NoReturn
+from typing import Any
 import pyaudio
-from pathlib import Path
-import json
 from pydub import AudioSegment # type: ignore
 import io
 
 from cortana.stt import get_pyaudio_input_devices
-from cortana.api import make_api_request, ApiType
+from cortana.tts_providers import get_provider
 
-VOICES = 'voices'
-VOICE= 'voices/{voice_id}'
-VOICE_SETTINGS = 'voices/{voice_id}/settings'
-TTS = 'text-to-speech/{voice_id}'
-TTS_STREAM = 'text-to-speech/{voice_id}/stream'
 PLAYBACK_BLOCK_SIZE=2048
 DOWNLOAD_BLOCK_SIZE=8*1024
-
-
-def get_voices() -> list[Any]:
-    if (voices_path:= Path('voices.json')).exists():
-        with open(voices_path, 'r') as f:
-            return json.load(f)['voices']
-    response = make_api_request('GET', ApiType.ELEVENLABS, VOICES)
-    with open('voices.json', 'w') as f:
-        json.dump(response, f, indent=4)
-    
-    if not response:
-        raise Exception('No voices found!')
-
-    return response.get('voices', [])
-
-
-def stream_text_to_voice(voice_id: str, text: str):
-    response_stream = make_api_request('POST', ApiType.ELEVENLABS, TTS_STREAM.format(voice_id=voice_id), data={
-  "text": "Oh, shampoo, that magical elixir that we all slather on our hair without a clue as to how it actually works. It's like putting faith in a wizard who claims to have a secret potion that will make your hair shine like diamonds.",
-  "voice_settings": {
-    "stability": 0.5,
-    "similarity_boost": 0.3
-  }
-}, stream=True)
-    return response_stream
-
-
-def get_text_to_voice(voice_id: str, text: str):
-    response = make_api_request('POST', ApiType.ELEVENLABS, TTS.format(voice_id=voice_id), data={
-        "text": text,
-        "voice_settings": {
-            "stability": 0.6,
-            "similarity_boost": 0.3
-        }
-    })
-    return response
-
-
-def get_non_premade_voices(voices: list[dict[Any, Any]]) -> list[dict[Any, Any]]:
-    return [
-        voice
-        for voice
-        in voices
-        if not voice.get('category', None)=='premade']
 
 
 def find_voice_by_name(voices: list[dict[Any, Any]], name: str) -> dict[Any, Any] | None:
@@ -93,18 +46,19 @@ def play_response(response_data, device: Any):
     stream.close()
     p.terminate()
 
-def tts_loop(text: str|None = None):
+def tts_loop(text: str|None = None, provider: str|None = None):
+    tts_provider = get_provider(provider)
     devices = get_pyaudio_input_devices()
     device = select_pyaudio_output_device(devices)
-    voices = get_voices()
-    voice = find_voice_by_name(get_non_premade_voices(voices), os.environ.get('ELEVENLABS_VOICE_NAME', ''))
+    voices = tts_provider.list_voices()
+    voice = find_voice_by_name(voices, tts_provider.voice_name)
     if not voice:
         raise Exception('Voice not found!')
     if not text:
         while True:
             text = input('Enter text to speak: ')
-            response_stream = get_text_to_voice(voice['voice_id'], text)
-            play_response(response_stream.content, device)
+            audio = tts_provider.synthesize(voice['voice_id'], text)
+            play_response(audio, device)
     else:
-        response_stream = get_text_to_voice(voice['voice_id'], text)
-        play_response(response_stream.content, device)
+        audio = tts_provider.synthesize(voice['voice_id'], text)
+        play_response(audio, device)

--- a/cortana/tts_providers.py
+++ b/cortana/tts_providers.py
@@ -1,0 +1,143 @@
+"""
+TTS provider abstraction so ElevenLabs and 60db can be used interchangeably.
+
+Every provider exposes the same minimal interface, which keeps the rest of the
+TTS pipeline (device selection + playback in tts.py) completely provider-agnostic:
+
+    - voice_name        the configured voice to look for (from .env)
+    - list_voices()     a normalized list of {'voice_id', 'name', ...} dicts
+    - synthesize(...)   audio bytes (mp3) ready for playback
+
+The provider is chosen by name: an explicit argument (e.g. the --provider CLI
+flag) takes precedence, otherwise the TTS_PROVIDER env var, otherwise elevenlabs.
+"""
+from dotenv import load_dotenv
+load_dotenv(override=True)
+import os
+import json
+import base64
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from cortana.api import make_api_request, ApiType
+
+
+class TTSProvider(ABC):
+    name: str
+
+    @property
+    @abstractmethod
+    def voice_name(self) -> str:
+        """The voice name to look for, read from this provider's .env var."""
+        ...
+
+    @abstractmethod
+    def list_voices(self) -> list[dict[str, Any]]:
+        """Normalized list of voices, each a dict with at least 'voice_id' and 'name'."""
+        ...
+
+    @abstractmethod
+    def synthesize(self, voice_id: str, text: str) -> bytes:
+        """Return mp3 audio bytes for the given text in the given voice."""
+        ...
+
+    def _read_cache(self, cache_path: Path) -> Any | None:
+        if cache_path.exists():
+            with open(cache_path, 'r') as f:
+                return json.load(f)
+        return None
+
+    def _write_cache(self, cache_path: Path, payload: Any) -> None:
+        with open(cache_path, 'w') as f:
+            json.dump(payload, f, indent=4)
+
+
+class ElevenLabsProvider(TTSProvider):
+    name = 'elevenlabs'
+    VOICES = 'voices'
+    TTS = 'text-to-speech/{voice_id}'
+    CACHE = Path('voices.json')
+
+    @property
+    def voice_name(self) -> str:
+        return os.environ.get('ELEVENLABS_VOICE_NAME', '')
+
+    def list_voices(self) -> list[dict[str, Any]]:
+        cached = self._read_cache(self.CACHE)
+        if cached is not None:
+            voices = cached.get('voices', []) if isinstance(cached, dict) else cached
+        else:
+            response = make_api_request('GET', ApiType.ELEVENLABS, self.VOICES)
+            if not response:
+                raise Exception('No voices found!')
+            self._write_cache(self.CACHE, response)
+            voices = response.get('voices', [])
+        # exclude elevenlabs' stock voices so we match cloned/custom ones by name
+        return [v for v in voices if v.get('category') != 'premade']
+
+    def synthesize(self, voice_id: str, text: str) -> bytes:
+        response = make_api_request('POST', ApiType.ELEVENLABS, self.TTS.format(voice_id=voice_id), data={
+            'text': text,
+            'voice_settings': {
+                'stability': float(os.environ.get('ELEVENLABS_STABILITY', 0.6)),
+                'similarity_boost': float(os.environ.get('ELEVENLABS_SIMILARITY_BOOST', 0.3)),
+            },
+        })
+        # elevenlabs returns raw mp3 bytes (non-json), so make_api_request hands back a Response
+        return response.content
+
+
+class SixtyDBProvider(TTSProvider):
+    name = '60db'
+    MYVOICES = 'myvoices'
+    TTS = 'tts-synthesize'
+    CACHE = Path('voices_60db.json')
+
+    @property
+    def voice_name(self) -> str:
+        return os.environ.get('SIXTYDB_VOICE_NAME', '')
+
+    def list_voices(self) -> list[dict[str, Any]]:
+        cached = self._read_cache(self.CACHE)
+        if cached is not None:
+            return cached.get('data', []) if isinstance(cached, dict) else cached
+        response = make_api_request('GET', ApiType.SIXTYDB, self.MYVOICES)
+        if not response or not response.get('data'):
+            raise Exception('No voices found!')
+        self._write_cache(self.CACHE, response)
+        # /myvoices only returns the user's own voices, so no premade filtering needed
+        return response.get('data', [])
+
+    def synthesize(self, voice_id: str, text: str) -> bytes:
+        response = make_api_request('POST', ApiType.SIXTYDB, self.TTS, data={
+            'text': text,
+            'voice_id': voice_id,
+            'output_format': 'mp3',  # mp3 keeps playback identical to the elevenlabs path
+            'enhance': os.environ.get('SIXTYDB_ENHANCE', 'true').strip().lower() == 'true',
+            'speed': float(os.environ.get('SIXTYDB_SPEED', 1)),
+            'stability': float(os.environ.get('SIXTYDB_STABILITY', 50)),
+            'similarity': float(os.environ.get('SIXTYDB_SIMILARITY', 75)),
+        })
+        if not response or not response.get('success'):
+            message = response.get('message') if isinstance(response, dict) else 'no response'
+            raise Exception(f'60db TTS failed: {message}')
+        # 60db returns json with base64-encoded audio rather than raw bytes
+        return base64.b64decode(response['audio_base64'])
+
+
+PROVIDERS: dict[str, type[TTSProvider]] = {
+    'elevenlabs': ElevenLabsProvider,
+    '60db': SixtyDBProvider,
+}
+
+
+def resolve_provider_name(provider: str | None = None) -> str:
+    name = (provider or os.environ.get('TTS_PROVIDER') or 'elevenlabs').strip().lower()
+    if name not in PROVIDERS:
+        raise ValueError(f"Unknown TTS provider '{name}'. Choose one of: {', '.join(PROVIDERS)}")
+    return name
+
+
+def get_provider(provider: str | None = None) -> TTSProvider:
+    return PROVIDERS[resolve_provider_name(provider)]()

--- a/example.env
+++ b/example.env
@@ -15,10 +15,25 @@ OPENAI_API_URL=api.openai.com/v1/
 OPENAI_WHISPER_MODEL=tiny
 OPENAI_CHATGPT_MODEL="gpt-4"
 
+# Text-to-speech provider: elevenlabs or 60db (default elevenlabs).
+# Override per-run with `--provider` on the tts/full/clone commands.
+TTS_PROVIDER=elevenlabs
+
 # Elevenlabs
 ELEVENLABS_API_URL=api.elevenlabs.io/v1/
 ELEVENLABS_API_KEY=
 ELEVENLABS_VOICE_NAME=Cortana
+ELEVENLABS_STABILITY=0.6
+ELEVENLABS_SIMILARITY_BOOST=0.3
+
+# 60db (https://docs.60db.ai). Auth is a Bearer token.
+SIXTYDB_API_URL=api.60db.ai/
+SIXTYDB_API_KEY=
+SIXTYDB_VOICE_NAME=Cortana
+SIXTYDB_STABILITY=50
+SIXTYDB_SIMILARITY=75
+SIXTYDB_SPEED=1
+SIXTYDB_ENHANCE=true
 
 # Sysem
 INPUT_DEVICE="Chat Input"


### PR DESCRIPTION
We added 60db as a second text-to-speech provider alongside ElevenLabs, switchable via TTS_PROVIDER in .env or --provider on the
  CLI.

  - cortana/api.py — added 60db to the API enum + Bearer auth, and fixed the JSON content-type check.
  - cortana/tts_providers.py (new) — a provider interface with ElevenLabsProvider and SixtyDBProvider, plus a get_provider()
  factory.
  - cortana/tts.py — made provider-agnostic (just device selection + buffered mp3 playback).
  - cli.py / app.py — added --provider flag, threaded through tts/full/clone.
  - example.env, .gitignore, README.md — new config vars, ignored the 60db voice cache, and updated docs.

  Scope: TTS only (STT stays on local Whisper), buffered playback for both, per-provider settings in .env.